### PR TITLE
make it work with HA

### DIFF
--- a/custom_components/renaultze/sensor.py
+++ b/custom_components/renaultze/sensor.py
@@ -46,7 +46,7 @@ async def async_setup_platform(hass, config, async_add_entities,
     _LOGGER.debug("Initialising renaultze platform")
     wrapper = MyRenaultService(config.get(CONF_USERNAME),
                                config.get(CONF_PASSWORD))
-    wrapper.initialise_configuration(config.get(CONF_ANDROID_LNG))
+    await wrapper.initialise_configuration(config.get(CONF_ANDROID_LNG))
 
     devices = [
         RenaultZESensor(wrapper,
@@ -108,6 +108,6 @@ class RenaultZESensor(Entity):
         try:
             jsonresult = await self._wrapper.apiGetBatteryStatus(self._vin)
             _LOGGER.debug("Update result: %s" % jsonresult)
-            self.process_response(jsonresult['attributes'])
+            self.process_response(jsonresult['data']['attributes'])
         except MyRenaultServiceException as e:
             _LOGGER.error("Update failed: %s" % e)


### PR DESCRIPTION
Small updates to your code for the new API to make it work in HA.

Other comments:

- I don't understand [the line 54 in `sensor.py`](https://github.com/epenet/hassRenaultZE/blob/e970406c7317545fcbf7fe751d51f72fd661c72e/custom_components/renaultze/sensor.py#L54). Perhaps there is a typo
- There are two `initialize_configuration` methods in `MyRenaultService.py` ([line 34](https://github.com/epenet/hassRenaultZE/blob/e970406c7317545fcbf7fe751d51f72fd661c72e/custom_components/renaultze/myrenaultservice/MyRenaultService.py#L34)). The first one seems not used.
- Is there any reason to not use directly the package developed by jamesremuscat ? In the future it could simplify the maintenance.
<img width="392" alt="Zoé" src="https://user-images.githubusercontent.com/93244/62014780-6ee91500-b1a5-11e9-9c7d-e4b1a37f339e.png">
