### PR TITLE
Add location attributes

### DIFF
--- a/custom_components/renaultze/sensor.py
+++ b/custom_components/renaultze/sensor.py
@@ -41,6 +41,9 @@ ATTR_CHARGE_MODE = 'charge_mode'
 ATTR_WHEN = 'when'
 ATTR_TEMPERATURE = 'temperature'
 ATTR_SCHEDULES = 'schedules'
+ATTR_LOCATION_LAT = 'location_latitude'
+ATTR_LOCATION_LON = 'location_longitude'
+ATTR_LOCATION_LAST_UPDATE = 'location_last_update'
 
 CONF_VIN = 'vin'
 CONF_ANDROID_LNG = 'android_lng'
@@ -231,6 +234,13 @@ class RenaultZESensor(Entity):
     def process_chargemode_response(self, jsonresult):
         """Update new state data for the sensor."""
         self._attrs[ATTR_CHARGE_MODE] = jsonresult.name
+    
+    def process_location_response(self, jsonresult):
+        """Update location data for the sensor."""
+        if 'gpsLatitude' in jsonresult:
+            self._attrs[ATTR_LOCATION_LAT] = jsonresult['gpsLatitude']
+            self._attrs[ATTR_LOCATION_LON] = jsonresult['gpsLongitude']
+            self._attrs[ATTR_LOCATION_LAST_UPDATE] = jsonresult['lastUpdateTime']
 
     def update(self):
         """Fetch new state data for the sensor.
@@ -265,6 +275,13 @@ class RenaultZESensor(Entity):
             self.process_chargemode_response(jsonresult)
         except Exception as e:
             _LOGGER.warning("Charge mode update failed: {0}".format(traceback.format_exc()))
+
+        try:
+            jsonresult =  self._vehicle.location()
+            _LOGGER.debug("Location update result: {0}".format(jsonresult))
+            self.process_location_response(jsonresult)
+        except Exception as e:
+            _LOGGER.warning("Location update failed: {0}".format(traceback.format_exc()))
 
     def ac_start(self, when=None, temperature=21):
         try:


### PR DESCRIPTION
Add location attributes. I believe it works only for ZE-50.

Below an example (probably not the best way) to have a device tracker based on new attributes. With this i'am able to see my zoe on a map.

```
  - alias: Zoe - Update location 
    trigger:
      platform: state
      entity_id:
        - sensor.zoe
    action:
      - service: device_tracker.see
        data_template:
          dev_id: zoe
          host_name: Zoe
          gps:
            - "{{ state_attr('sensor.zoe','location_latitude')|round(6)|float }}"
            - "{{ state_attr('sensor.zoe','location_longitude')|round(6)|float }}"
```


The device is in known_devices file too :
```
zoe:
  icon: mdi:car
  mac:
  name: zoe
  picture:
  track: true
```