### PR TITLE
Fix charge mode result

### DIFF
--- a/custom_components/renaultze/sensor.py
+++ b/custom_components/renaultze/sensor.py
@@ -230,7 +230,7 @@ class RenaultZESensor(Entity):
 
     def process_chargemode_response(self, jsonresult):
         """Update new state data for the sensor."""
-        self._attrs[ATTR_CHARGE_MODE] = jsonresult.name
+        self._attrs[ATTR_CHARGE_MODE] = jsonresult.name if hasattr(jsonresult, 'name') else jsonresult
 
     def update(self):
         """Fetch new state data for the sensor.


### PR DESCRIPTION
Sometimes Pyze charge mode result is a string. Causes the following error in HA :
```
Logger: custom_components.renaultze.sensor
Source: custom_components/renaultze/sensor.py:284
Integration: renaultze (documentation)
First occurred: 16:42:35 (1 occurrences)
Last logged: 16:42:35

Charge mode update failed: Traceback (most recent call last): File "/config/custom_components/renaultze/sensor.py", line 282, in update self.process_chargemode_response(jsonresult) File "/config/custom_components/renaultze/sensor.py", line 242, in process_chargemode_response self._attrs[ATTR_CHARGE_MODE] = jsonresult.name #if hasattr(jsonresult, 'name') else jsonresult AttributeError: 'str' object has no attribute 'name'
```

This PR fix the problem.