### PR TITLE
Fix batteryAvailableEnergy is not a boolean

### DIFF
--- a/custom_components/renaultze/sensor.py
+++ b/custom_components/renaultze/sensor.py
@@ -184,7 +184,7 @@ class RenaultZESensor(Entity):
             self._state = jsonresult.get('batteryLevel')
             
         if 'batteryAvailableEnergy' in jsonresult:
-            self._attrs[ATTR_BATTERY_AVAILABLE_ENERGY] = jsonresult['batteryAvailableEnergy'] > 0
+            self._attrs[ATTR_BATTERY_AVAILABLE_ENERGY] = jsonresult['batteryAvailableEnergy']
         if 'chargingStatus' in jsonresult:
             self._attrs[ATTR_CHARGING] = jsonresult['chargingStatus'] > 0
             


### PR DESCRIPTION
As batteryAvailableEnergy is not a boolean, it is better to push the value.

For HA users who want a boolean, they can create a sensor to test "> 0". But i think most user want the value in kWh. i hope for them that batteryAvailableEnergy is always > 0 :-)
