### PR TITLE
Add option to use kWh instead of Wh

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,14 @@ sensor:
     vin: XXXXXXXX
     android_lng: fr_FR
     k_account_id: abcdef123456789
+    use_kwh: True
 ```
 
 Please note that these configuration setting are optional:
 - name *(defaults to VIN)*
 - android_lng *(defaults to fr_FR)*
 - k_account_id *(default to empty, which may cause a warning if multiple accounts are associated with the credentials)*
+- use_kwh *(Some new cars, etc. ZE50, report charging power in kWh instead of Wh. Set to true if your car does this)*
 
 ## Converting attributes to sensors
 Template sensors can be added to your configuration.yaml to display the attributes as sensors.

--- a/custom_components/renaultze/sensor.py
+++ b/custom_components/renaultze/sensor.py
@@ -83,7 +83,7 @@ async def async_setup_platform(hass, config, async_add_entities,
     cred = CredentialStore()
     cred.clear()
 
-   url = 'https://renault-wrd-prod-1-euw1-myrapp-one.s3-eu-west-1.amazonaws.com/configuration/android/config_{0}.json'.format(config.get(CONF_ANDROID_LNG))
+    url = 'https://renault-wrd-prod-1-euw1-myrapp-one.s3-eu-west-1.amazonaws.com/configuration/android/config_{0}.json'.format(config.get(CONF_ANDROID_LNG))
     async with aiohttp.ClientSession(
             ) as session:
         async with session.get(url) as response:


### PR DESCRIPTION
Some new cars, etc. ZE50 report charging power in kWh instead of Wh like they used to do before. 
Add configuration option to not divide by 1000.