### PR TITLE
Add charging time entity sensor for a vehicle

### DIFF
--- a/custom_components/renault/sensor.py
+++ b/custom_components/renault/sensor.py
@@ -55,6 +55,7 @@ async def get_vehicle_entities(hass, vehicle_proxy: PyzeVehicleProxy):
     entities.append(RenaultBatteryLevelSensor(vehicle_proxy, "Battery Level"))
     entities.append(RenaultChargeModeSensor(vehicle_proxy, "Charge Mode"))
     entities.append(RenaultChargeStateSensor(vehicle_proxy, "Charge State"))
+    entities.append(RenaultChargingRemainingTimeSensor(vehicle_proxy, "Charging Remaining Time"))
     entities.append(RenaultChargingPowerSensor(vehicle_proxy, "Charging Power"))
     entities.append(RenaultMileageSensor(vehicle_proxy, "Mileage"))
     entities.append(


### PR DESCRIPTION
Hi @epenet,

This is a simple suggested fix for charging remaining time missing as a sensor in v3.0.0rc2.
