### PR TITLE
Ignore Kamereon account with no vehicle attached

### DIFF
--- a/custom_components/renault/pyzeproxy.py
+++ b/custom_components/renault/pyzeproxy.py
@@ -83,10 +83,12 @@ class PyzeProxy:
         for account_details in await self._hass.async_add_executor_job(
             self._kamereon.get_accounts
         ):
-            # Need to copy self._kameron as it seems impossible to overwrite account.
-            kameron = deepcopy(self._kamereon)
-            kameron.set_account_id(account_details["accountId"])
-            vehicles = await self._hass.async_add_executor_job(kameron.get_vehicles)
+            self._kamereon.set_account_id(account_details["accountId"])
+            vehicles = await self._hass.async_add_executor_job(
+                self._kamereon.get_vehicles
+            )
+            # get_vehicles() use cache: need to empty it between each iteration in the loop
+            self._kamereon.get_vehicles.cache_clear()
 
             # Skip the account if no vehicles found in it.
             if len(vehicles["vehicleLinks"]) != 0:

--- a/custom_components/renault/pyzeproxy.py
+++ b/custom_components/renault/pyzeproxy.py
@@ -2,8 +2,6 @@
 import asyncio
 import logging
 
-from copy import deepcopy
-
 from pyze.api import BasicCredentialStore, Gigya, Kamereon, Vehicle
 
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME


### PR DESCRIPTION
When setting the integration, all Kamereon accounts associated to the users are
shown. Some of them have no vehicles inside and can disturb the user experience.
So this modification add a check to ignore account without vehicles attached.

Fix: #55